### PR TITLE
Feed provider analysis fixes

### DIFF
--- a/packages/tether/lib/generators/feed_provider_generator.dart
+++ b/packages/tether/lib/generators/feed_provider_generator.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+
 import 'package:path/path.dart' as p;
 import 'package:tether_libs/utils/logger.dart'; // Assuming you have a Logger utility
 
@@ -19,7 +20,7 @@ class FeedProviderGenerator {
     buffer.writeln('');
     buffer.writeln("""
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: constant_identifier_names
+// ignore_for_file: constant_identifier_names, avoid_public_notifier_properties
 
 import 'dart:convert';
 
@@ -312,7 +313,7 @@ class FeedStreamNotifier<TModel extends TetherModel<TModel>>
                       itemSourceTable:
                           effectiveQuery
                               .tableName, // Use effective query's table
-                      itemSourceId: e.value.localId,
+                      itemSourceId: e.value.localId.toString(),
                       displayOrder: e.key,
                     ),
                   )
@@ -333,7 +334,7 @@ class FeedStreamNotifier<TModel extends TetherModel<TModel>>
                       itemSourceTable:
                           effectiveQuery
                               .tableName, // Use effective query's table
-                      itemSourceId: e.value.localId,
+                      itemSourceId: e.value.localId.toString(),
                       displayOrder: e.key,
                     ),
                   )
@@ -394,7 +395,7 @@ class FeedStreamNotifier<TModel extends TetherModel<TModel>>
                       itemSourceTable:
                           effectiveQuery
                               .tableName, // Use effective query's table
-                      itemSourceId: item.localId,
+                      itemSourceId: item.localId.toString(),
                       // displayOrder for addItemsToEnd is handled by the manager
                       displayOrder: -1, // Or let manager handle it
                     ),


### PR DESCRIPTION
Fixes `The argument type 'dynamic' can't be assigned to the parameter type 'String'.` in the feed provider. This error only shows up if you have `strict-casts: true` set in analysis options.

Also included ignore for `avoid_public_notifier_properties` to ignore a bunch of warnings.